### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/src/Pyomo.jl
+++ b/src/Pyomo.jl
@@ -29,7 +29,7 @@ function __init__()
     PythonCall.pycopy!(dae, pyimport("pyomo.dae"))
     PythonCall.pycopy!(opt, pyimport("pyomo.opt"))
     PythonCall.pycopy!(math, pyimport("math"))
-    PythonCall.pycopy!(compare_expressions, pyimport("pyomo.core.expr.compare" => "compare_expressions"))
+    return PythonCall.pycopy!(compare_expressions, pyimport("pyomo.core.expr.compare" => "compare_expressions"))
 end
 
 end # module Pyomo

--- a/src/concretemodel.jl
+++ b/src/concretemodel.jl
@@ -5,14 +5,14 @@ end
 const SymbolicConcreteModel = Symbolics.symstruct(ConcreteModel)
 
 function ConcreteModel()
-    ConcreteModel(pyomo.ConcreteModel())
+    return ConcreteModel(pyomo.ConcreteModel())
 end
 
 PythonCall.Py(x::ConcreteModel) = x.__py__
 PythonCall.pyconvert(::Type{ConcreteModel}, x::Py) = T(x)
 
 function Base.getproperty(model::ConcreteModel, sym::Symbol)
-    if isequal(sym, :__py__)
+    return if isequal(sym, :__py__)
         getfield(model, :__py__)
     else
         getproperty(getfield(model, :__py__), sym)
@@ -20,7 +20,7 @@ function Base.getproperty(model::ConcreteModel, sym::Symbol)
 end
 
 function Base.setproperty!(model::ConcreteModel, sym::Symbol, obj)
-    if isequal(sym, :__py__)
+    return if isequal(sym, :__py__)
         setfield!(model, :__py__, obj)
     else
         setproperty!(model.:__py__, sym, obj)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -1,11 +1,11 @@
 function SolverFactory(solver::String)
-    pyomo.SolverFactory(solver)
+    return pyomo.SolverFactory(solver)
 end
 
 function get_results(model, sym)
     var = getproperty(model, sym)
     idxs = pyconvert(Array, var.index_set())
-    [pyomo.value(var[i]) for i in idxs]
+    return [pyomo.value(var[i]) for i in idxs]
 end
 
 abstract type DiscretizationMethod end
@@ -20,15 +20,15 @@ struct LagrangeLegendre <: DiscretizationMethod
 end
 
 function TransformationFactory(m::DiscretizationMethod)
-    pyomo.TransformationFactory(method_string(m))
+    return pyomo.TransformationFactory(method_string(m))
 end
 
 function is_finite_difference(dm::DiscretizationMethod)
-    dm isa Union{ForwardEuler, BackwardEuler, MidpointEuler}
+    return dm isa Union{ForwardEuler, BackwardEuler, MidpointEuler}
 end
 
 function method_string(dm::DiscretizationMethod)
-    is_finite_difference(dm) ? "dae.finite_difference" : "dae.collocation"
+    return is_finite_difference(dm) ? "dae.finite_difference" : "dae.collocation"
 end
 scheme_string(::ForwardEuler) = "FORWARD"
 scheme_string(::MidpointEuler) = "CENTRAL"

--- a/src/symbolics.jl
+++ b/src/symbolics.jl
@@ -12,7 +12,7 @@ Base.promote_rule(::Type{PyomoVar}, ::Type{S}) where {S <: Number} = PyomoVar
 # Symbolic indexing
 Base.getindex(v::PyomoVar, i::Vararg{Integer}) = pyomo_getindex(v, i...)
 function Base.getindex(v::Union{PyomoVar, BasicSymbolic{Struct{PyomoVar}}}, args...)
-    if v isa BasicSymbolic || any(t -> t <: Union{Num, Symbolic}, typeof(args).types)
+    return if v isa BasicSymbolic || any(t -> t <: Union{Num, Symbolic}, typeof(args).types)
         wrap(Term{PyomoVar}(pyomo_getindex, [v, args...]))
     else
         pyomo_getindex(v, args...)
@@ -41,7 +41,7 @@ _float_if_irrational(x::Real) = x isa Irrational ? float(x) : x
 ==(x::C, y::C) where {C <: PyomoVar} = C(pycall(==, x, _float_if_irrational(y)))
 
 function Base.isequal(x::C, y::Number) where {C <: PyomoVar}
-    pyconvert(Bool, pycall(Pyomo.compare_expressions, x, y))
+    return pyconvert(Bool, pycall(Pyomo.compare_expressions, x, y))
 end
 Base.iszero(x::C) where {C <: PyomoVar} = false
 Base.isone(x::C) where {C <: PyomoVar} = false


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)