### PR TITLE
Migrate CI to centralized SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,4 +1,4 @@
-name: "Format Check"
+name: "Spell Check"
 
 on:
   push:
@@ -13,6 +13,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
 
 jobs:
-  runic:
-    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+  spellcheck:
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Normalizes Pyomo.jl CI toward the centralized SciML reusable workflows (all pinned `@v1`).

## Workflows converted
- **`FormatCheck.yml`** — converted from an inline `fredrikekre/runic-action` job to the centralized `runic.yml@v1` caller. The repo already ran Runic, so no reformatting was required; the source was already Runic-clean.

## Workflows added
- **`SpellCheck.yml`** — new `spellcheck.yml@v1` caller (crate-ci/typos). Ran `typos` locally: **no findings**, so no `_typos.toml` was needed.

## Dependency automation
- **`.github/dependabot.yml`** — added (none existed). Contains a `github-actions` block (`/`, weekly) and a `julia` block (`/`, daily, grouped `all-julia-packages: ["*"]`). Only the root has a `Project.toml`; there is no `docs/` or `test/` Project.toml.
- **CompatHelper** — none present, nothing removed.

## Not added (intentional)
- **Tests / Downgrade** — this package has **no test suite** (no `test/` directory, no `test/runtests.jl`, and no `[extras]`/`[targets]` test section in `Project.toml`). Adding `tests.yml@v1` or `downgrade.yml@v1` callers would produce guaranteed-red checks because `Pkg.test` has nothing to run. These should be added once an actual test suite exists.
- **Documentation** — no `docs/` directory, so no `documentation.yml@v1` caller.
- **Downstream / Benchmark / QA** — none existed previously; not invented.
- **TagBot** — the repo had no TagBot; left untouched (registry tagging is presumably handled elsewhere / not configured here).

## Heads-up
- **Check names change**: the format check is no longer the inline `format-check / runic` job; branch-protection required-status-checks should be updated to the new centralized job names (Runic Format Check, Spell Check with Typos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)