### PR TITLE
Add downgrade smoke tests

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,19 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  test:
+    name: Downgrade
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+    secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,10 @@ julia = "1.10"
 NaNMath = "1.1.3"
 PythonCall = "0.9.24"
 Symbolics = "6.39.1"
+Test = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,7 @@
+using Pyomo
+using Test
+
+@testset "Pyomo smoke test" begin
+    model = ConcreteModel()
+    @test model isa ConcreteModel
+end


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- add the standard SciML downgrade workflow on Julia LTS
- declare the `Test` stdlib as a test dependency
- add a smoke test that constructs a Pyomo `ConcreteModel`

## Local verification

- released `julia-actions/julia-downgrade-compat` v2 action (commit `fab1def`): passed
- Julia 1.10 strict floor `Pkg.test` with resolution disabled: 1/1 passed; `Pyomo tests passed`
- Runic 1.7.0: 5/5 Julia files passed
- actionlint: passed
- `git diff --check`: passed

The strict test used the real PythonCall/CondaPkg-managed Pyomo environment.